### PR TITLE
Adding man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+man/dist

--- a/man/man1/projinfo.1.md
+++ b/man/man1/projinfo.1.md
@@ -1,0 +1,45 @@
+% PROJINFO(1) 0.1.0 | ProjInfo Documentation
+% dk949
+% 15 March 2022
+
+# NAME
+
+projinfo - Language stats for your projects
+
+# SYNOPSIS
+
+projinfo \[OPTIONS] \[DIR]
+
+# DESCRIPTION
+
+Think of something to write here
+
+# OPTIONS
+
+**-a**, **--all**
+: Include all file types
+
+**-h**, **--help**
+: Print help information
+
+**-i**, **--ignore** <IGNORE>
+: List of files or directories to ignore You can pass list as a single comma-separated list, or by using the flag multiple times
+
+**-m**, **--most** <MOST>
+: Maximum number of entries to show (default: 5)
+
+**--no-git**
+: Do not use git even if the directoryis a dir repository
+
+**--no-skip-dots**
+: Do not skip hidden/dot directories
+
+**-t**, **--types** <TYPES>
+: List of file types to include in the summary. Does not support passing as comma-separated list (possible values: programming, markup, data, prose)
+
+**-V**, **--version**
+: Print version information
+
+# BUGS
+
+No known bugs. To report any [do so on GitHub](https://github.com/dk949/ProjInfo/issues).


### PR DESCRIPTION
They are in markdown for ease of writing and can be converted to "proper" man page with the following `pandoc` command:

```shell
$ pandoc --standalone --to man ./man/man1/projinfo.md -o ./man/dist/man1/projinfo.1
```

After that, all the files in the `./man/dist/` directory (including subdirectories) have to be copied to the OS's respective directory for the man pages.

I dunno how to implement this but you could try to look in `manpath` or `man -d`, most likely to be in `/usr/share/man/`, `/usr/local/man/` but am not sure.